### PR TITLE
TECH: Adding cloudwatch log group management

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 container:
   image: smartrent/terraform-ci:0.14.4
-  cpu: 0.5
+  cpu: 1
 
 base: &base
   timeout_in: 30m

--- a/main.tf
+++ b/main.tf
@@ -153,3 +153,9 @@ resource "aws_iam_role_policy_attachment" "lambda_datadog_push" {
   policy_arn = aws_iam_policy.labmda_execution.arn
   role       = aws_iam_role.lambda_execution.name
 }
+
+# Manage Log Group
+resource "aws_cloudwatch_log_group" "log_group" {
+  name              = "/aws/lambda/${aws_lambda_function.logs_to_datadog.function_name}"
+  retention_in_days = 30
+}

--- a/main.tf
+++ b/main.tf
@@ -157,5 +157,5 @@ resource "aws_iam_role_policy_attachment" "lambda_datadog_push" {
 # Manage Log Group
 resource "aws_cloudwatch_log_group" "log_group" {
   name              = "/aws/lambda/${aws_lambda_function.logs_to_datadog.function_name}"
-  retention_in_days = 30
+  retention_in_days = var.retention
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,9 @@ variable "tags" {
   type        = map(string)
   description = "Tags to assign to resources created by this module"
 }
+
+variable "retention" {
+  type        = number
+  description = "The log group retention in days"
+  default     = 30
+}


### PR DESCRIPTION
## Description 

Creates the log group for the lambda function and sets retention in days. 
