### PR TITLE
TECH-1256, Add another SNS trigger to lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,6 @@ resource "aws_sns_topic_subscription" "sns_topic_arn" {
 
 resource "aws_lambda_permission" "sns_topic_arn" {
   count         = var.provision_trigger ? length(var.sns_topic_arn) : 0
-  #statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.logs_to_datadog.function_name
   principal     = "sns.amazonaws.com"

--- a/main.tf
+++ b/main.tf
@@ -163,16 +163,17 @@ resource "aws_cloudwatch_log_group" "log_group" {
 }
 
 resource "aws_sns_topic_subscription" "sns_topic_arn" {
-  topic_arn = var.sns_topic_arn
+  count     = var.provision_trigger ? length(var.sns_topic_arn) : 0
+  topic_arn = var.sns_topic_arn[count.index]
   protocol  = "lambda"
   endpoint  = aws_lambda_function.logs_to_datadog.arn
 }
 
 resource "aws_lambda_permission" "sns_topic_arn" {
-  statement_id  = "AllowExecutionFromSNS"
+  count         = var.provision_trigger ? length(var.sns_topic_arn) : 0
+  #statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.logs_to_datadog.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = var.sns_topic_arn
+  source_arn    = var.sns_topic_arn[count.index]
 }
-

--- a/main.tf
+++ b/main.tf
@@ -162,17 +162,17 @@ resource "aws_cloudwatch_log_group" "log_group" {
   tags              = local.tags
 }
 
-resource "aws_sns_topic_subscription" "sns_topic_arn" {
-  count     = var.provision_trigger ? length(var.sns_topic_arn) : 0
-  topic_arn = var.sns_topic_arn[count.index]
+resource "aws_sns_topic_subscription" "sns_topic_arns" {
+  count     = var.provision_trigger ? length(var.sns_topic_arns) : 0
+  topic_arn = var.sns_topic_arns[count.index]
   protocol  = "lambda"
   endpoint  = aws_lambda_function.logs_to_datadog.arn
 }
 
-resource "aws_lambda_permission" "sns_topic_arn" {
-  count         = var.provision_trigger ? length(var.sns_topic_arn) : 0
+resource "aws_lambda_permission" "sns_topic_arns" {
+  count         = var.provision_trigger ? length(var.sns_topic_arns) : 0
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.logs_to_datadog.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = var.sns_topic_arn[count.index]
+  source_arn    = var.sns_topic_arns[count.index]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,14 @@ variable "retention" {
   default     = 30
 }
 
+variable "provision_trigger" {
+  type        = bool
+  description = "Whether or not to create a lambda trigger from an SNS topic"
+  default     = "false"
+}
+
 variable "sns_topic_arn" {
-  type        = string
+  type        = list(string)
   description = "SNS Topic ARN"
+  default     = ["undefined"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,8 +52,8 @@ variable "provision_trigger" {
   default     = "false"
 }
 
-variable "sns_topic_arn" {
+variable "sns_topic_arns" {
   type        = list(string)
-  description = "SNS Topic ARN"
+  description = "SNS Topic ARNs"
   default     = ["undefined"]
 }


### PR DESCRIPTION
My merge yesterday worked if you wanted to create a trigger with an SNS topic, but if you left it out, it crashed. Also, I wanted to be able to add a second trigger. I created a boolean with the default set to "false", so if you don't want to create a trigger, it ignores everything else. Then you can create a list of SNS topic ARNs and it will create the triggers for them.

I don't know why the Cirrus build is failing. I ran this in TF and it worked fine. It looks like it's complaining about something in the formatting, but it looks fine to me.