### PR TITLE
TECH-2558: logs_to_datadog Lambda Log Filtering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,8 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_API_KEY_SECRET_ARN = aws_secretsmanager_secret.api-key.arn
       DD_SITE               = var.dd_site
       DD_ENHANCED_METRICS   = var.enhanced_metrics
+      ## Filter out lambda platform logs
+      EXCLUDE_AT_MATCH = "\"(START|END|REPORT) RequestId:\\s"
     }
   }
 


### PR DESCRIPTION
We currently exclude all `INFO` type logs from this lambda function.  Instead of paying for ingesting those logs just to filter them out of the index, we can just not send them at all. 

[Log Examples via LiveTail
](https://app.datadoghq.com/logs/livetail?query=source%3Alambda%20host%3Aarn%5C%3Aaws%5C%3Alambda%5C%3A%2A%5C%3Afunction%5C%3Alogs_to_datadog%20status%3Ainfo&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1666209932660&to_ts=1666210832660&live=true)
![Screen Shot 2022-10-19 at 1 30 39 PM](https://user-images.githubusercontent.com/54445269/196797610-3194d2f9-51b2-4825-b90e-c45a508bd6f9.png)
![Screen Shot 2022-10-19 at 1 31 32 PM](https://user-images.githubusercontent.com/54445269/196797782-95a04198-0a29-436a-891a-e10cff855636.png)


References: 
https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#log-filtering-optional
https://github.com/DataDog/datadog-serverless-functions/blob/118e35a3a162f9fbbc2f98103040eb3aedf69805/aws/logs_monitoring/logs.py#L57
https://github.com/DataDog/datadog-serverless-functions/blob/118e35a3a162f9fbbc2f98103040eb3aedf69805/aws/logs_monitoring/settings.py#L180