### PR TITLE
TECH-2572: Change Python Layer to 60

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "layers" {
 variable "datadog_python_layer_version" {
   type        = number
   description = "The version of the Datadog Python Layer"
-  default     = 63
+  default     = 60
 }
 
 variable "datadog_extension_layer_version" {


### PR DESCRIPTION
We tried version 63, but there are breaking changes in 61 and we saw some errors when deploying to DEV and QA. Trying version 60 to see if that clears it up.