### PR TITLE
TECH-2572: Updating DataDog Log Forwarder

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "datadog_forwarder_version" {
 variable "runtime" {
   type        = string
   description = "The version of the runtime to use"
-  default     = "3.7"
+  default     = "3.8"
 }
 
 variable "tags" {
@@ -86,11 +86,11 @@ variable "layers" {
 variable "datadog_python_layer_version" {
   type        = number
   description = "The version of the Datadog Python Layer"
-  default     = 60
+  default     = 63
 }
 
 variable "datadog_extension_layer_version" {
   type        = number
   description = "The version of the Datadog Extension Layer"
-  default     = 31
+  default     = 32
 }


### PR DESCRIPTION
Changing back to Python 3.7 didn't fix things, and it actually broke DEV, so I'm switching back to Python 3.8 and updating the other layers to the most recent version. Still waiting for DataDog support to resolve the underlying issue.