### PR TITLE
TECH-2558: Filter out Lambda Platform Logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_SITE               = var.dd_site
       DD_ENHANCED_METRICS   = var.enhanced_metrics
       ## Filter out lambda platform logs
+      DD_LOGS_CONFIG_PROCESSING_RULES = "[{\"type\": \"exclude_at_match\", \"name\": \"exclude_start_and_end_logs\", \"pattern\": \"(START|END) RequestId\"}]"
       EXCLUDE_AT_MATCH = "\"(START|END) RequestId:\\s"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_ENHANCED_METRICS   = var.enhanced_metrics
       ## Filter out lambda platform logs
       DD_LOGS_CONFIG_PROCESSING_RULES = "[{\"type\": \"exclude_at_match\", \"name\": \"exclude_start_and_end_logs\", \"pattern\": \"(START|END) RequestId\"}]"
-      EXCLUDE_AT_MATCH = "\"(START|END) RequestId:\\s"
+      EXCLUDE_AT_MATCH                = "\"(START|END) RequestId:\\s"
     }
   }
 


### PR DESCRIPTION
We currently exclude these logs from our index.  This is to stop sending the START|STOP logs.  Note: We keep sending the REPORT logs as they are used for datadog serverless observability (We will continue to exclude these from our index though). 