### PR TITLE
fix: Remove provider-determined attribute from `lifecycle.ignore_changes`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,12 +48,6 @@ resource "aws_lambda_function" "logs_to_datadog" {
 
   layers = local.layers
 
-  lifecycle {
-    ignore_changes = [
-      last_modified,
-    ]
-  }
-
   tracing_config {
     mode = "Active"
   }


### PR DESCRIPTION
## Description

We have these warnings showing up: 

```
╷
│ Warning: Redundant ignore_changes element
│ 
│   on .terraform/modules/datadog-log-forwarder-lambda/main.tf line 24, in resource "aws_lambda_function" "logs_to_datadog":
│   24: resource "aws_lambda_function" "logs_to_datadog" {
│ 
│ Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the argument in configuration after the object has been created, retaining the value originally configured.
│ 
│ The attribute last_modified is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.
╵
```

After this change, seeing a clean diff. For visibility, there is an open issue where others are still seeing a diff for `last_modified` but this looks to be potentially an invalid combination of arguments. Not seeing the same thing on our end. https://github.com/hashicorp/terraform-provider-aws/issues/29085 

