### PR TITLE
TECH: Add kms key output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "lambda_function_arn" {
 output "lambda_iam_role_arn" {
   value = aws_iam_role.lambda_execution.arn
 }
+
+output "kms_key_arn" {
+  value = aws_kms_key.datadog.arn
+}


### PR DESCRIPTION
## Description
Add an output for the KMS key arn.  This is needed by CI when running plans.
## Steps to Test

1.

## Links

- JIRA Task: [TECH-](https://smartrent.atlassian.net/browse/TECH-)

## Screenshots
