### PR TITLE
TECH: Allow a list of bucket arns

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,9 +88,8 @@ data "aws_iam_policy_document" "lambda_runtime" {
       "s3:GetObject",
     ]
 
-    resources = [
-      "${var.bucket}/*",
-    ]
+    resources = formatlist("%s/*", var.bucket_arns)
+
   }
   statement {
     sid = "AllowXRay"

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,9 @@ variable "environment_name" {
   description = "Environment name: dev, qa, prod"
 }
 
-variable "bucket" {
-  type        = string
-  description = "The s3 bucket ARN"
+variable "bucket_arns" {
+  type        = list(string)
+  description = "A list of s3 bucket ARNs"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## Description

Allow passing a list of s3 buckets to add to lambda execution permissions for GetObject.

Tested in referenced PR. 
