### PR TITLE
TECH-4561: Add permission for any /aws/rds/* cloudwatch logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -183,7 +183,7 @@ resource "aws_lambda_permission" "sns_topic_arns" {
 
 resource "aws_lambda_permission" "rds_logs" {
   count         = var.rds_logs ? 1 : 0
-  statement_id = "${local.account_id}-${var.aws_region}-rds-logs-to-datadog"
+  statement_id  = "${local.account_id}-${var.aws_region}-rds-logs-to-datadog"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.logs_to_datadog.function_name
   principal     = "logs.${var.aws_region}.amazonaws.com"

--- a/main.tf
+++ b/main.tf
@@ -183,8 +183,9 @@ resource "aws_lambda_permission" "sns_topic_arns" {
 
 resource "aws_lambda_permission" "rds_logs" {
   count         = var.rds_logs ? 1 : 0
+  statement_id = "${local.account_id}-${var.aws_region}-rds-logs-to-datadog"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.logs_to_datadog.function_name
-  principal     = "logs.amazonaws.com"
+  principal     = "logs.${var.aws_region}.amazonaws.com"
   source_arn    = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/rds/*:*"
 }

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,13 @@ locals {
     "arn:aws:lambda:${var.aws_region}:464622532012:layer:Datadog-Python${replace(var.runtime, ".", "")}:${var.datadog_python_layer_version}",
     "arn:aws:lambda:${var.aws_region}:464622532012:layer:Datadog-Extension:${var.datadog_extension_layer_version}",
   ] : []
+  account_id = data.aws_caller_identity.current.account_id
   tags = merge(var.tags, {
     service : "logs_to_datadog"
   })
 }
+
+data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "datadog" {
   description = "KMS key for datadog lambda"
@@ -176,4 +179,12 @@ resource "aws_lambda_permission" "sns_topic_arns" {
   function_name = aws_lambda_function.logs_to_datadog.function_name
   principal     = "sns.amazonaws.com"
   source_arn    = var.sns_topic_arns[count.index]
+}
+
+resource "aws_lambda_permission" "rds_logs" {
+  count         = var.rds_logs ? 1 : 0
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.logs_to_datadog.function_name
+  principal     = "logs.amazonaws.com"
+  source_arn    = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/rds/*"
 }

--- a/main.tf
+++ b/main.tf
@@ -186,5 +186,5 @@ resource "aws_lambda_permission" "rds_logs" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.logs_to_datadog.function_name
   principal     = "logs.amazonaws.com"
-  source_arn    = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/rds/*"
+  source_arn    = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/rds/*:*"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -94,3 +94,9 @@ variable "datadog_extension_layer_version" {
   description = "The version of the Datadog Extension Layer"
   default     = 34
 }
+
+variable "rds_logs" {
+  type        = bool
+  description = "Whether to create lambda resource policy for sending all /aws/rds/* cloudwatch logs to the datadog log forwarder"
+  default     = true
+}


### PR DESCRIPTION
## Description

To consolidate resource policy permissions since it has a 20KB size limit, we can add the option to grant permission to the lambda function for all `/aws/rds/*` log groups. Then remove the individual log group resource policies once configured. See mentioned PRs for details. 

https://repost.aws/knowledge-center/lambda-resource-based-policy-size-error