### PR TITLE
TECH: Disable access logging on s3 tags cache bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,20 @@ Version numbers for datadog_extension_layer_version can be found here: <https://
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_datadog_serverless_s3"></a> [datadog\_serverless\_s3](#module\_datadog\_serverless\_s3) | git@github.com:smartrent/terraform-aws-s3.git | 2.1.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.cloudwatch_logs_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.labmda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.cloudwatch_logs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_logs_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_datadog_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
@@ -45,6 +50,9 @@ No modules.
 | [aws_secretsmanager_secret.api-key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_sns_topic_subscription.sns_topic_arns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.cloudwatch_logs_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cloudwatch_logs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_runtime](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -54,7 +62,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_bucket_arns"></a> [bucket\_arns](#input\_bucket\_arns) | A list of s3 bucket ARNs | `list(string)` | n/a | yes |
-| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | The version of the Datadog Extension Layer | `number` | `63` | no |
+| <a name="input_datadog_extension_layer_version"></a> [datadog\_extension\_layer\_version](#input\_datadog\_extension\_layer\_version) | The version of the Datadog Extension Layer | `number` | `64` | no |
 | <a name="input_datadog_forwarder_version"></a> [datadog\_forwarder\_version](#input\_datadog\_forwarder\_version) | The Datadog Forwarder version to use | `string` | `"3.121.0"` | no |
 | <a name="input_datadog_python_layer_version"></a> [datadog\_python\_layer\_version](#input\_datadog\_python\_layer\_version) | The version of the Datadog Python Layer | `number` | `98` | no |
 | <a name="input_dd_site"></a> [dd\_site](#input\_dd\_site) | The Datadog Site Address | `string` | n/a | yes |
@@ -67,6 +75,7 @@ No modules.
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | Amount of reserved concurrent executions for this lambda function | `number` | `100` | no |
 | <a name="input_retention"></a> [retention](#input\_retention) | The log group retention in days | `number` | `30` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | The version of the runtime to use | `string` | `"3.11"` | no |
+| <a name="input_s3_access_logging_bucket"></a> [s3\_access\_logging\_bucket](#input\_s3\_access\_logging\_bucket) | The bucket name for S3 access logging | `string` | `""` | no |
 | <a name="input_sns_topic_arns"></a> [sns\_topic\_arns](#input\_sns\_topic\_arns) | SNS Topic ARNs | `list(string)` | <pre>[<br>  "undefined"<br>]</pre> | no |
 | <a name="input_store_failed_events"></a> [store\_failed\_events](#input\_store\_failed\_events) | Whether to store failed events in the log forwarder | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to assign to resources created by this module | `map(string)` | n/a | yes |
@@ -76,6 +85,10 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_bucket_arns"></a> [bucket\_arns](#output\_bucket\_arns) | n/a |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
+| <a name="output_clouddwatch_kms_policy"></a> [clouddwatch\_kms\_policy](#output\_clouddwatch\_kms\_policy) | n/a |
+| <a name="output_cloudwatch_role_arn"></a> [cloudwatch\_role\_arn](#output\_cloudwatch\_role\_arn) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
 | <a name="output_lambda_api_key_secret"></a> [lambda\_api\_key\_secret](#output\_lambda\_api\_key\_secret) | n/a |
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | n/a |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Version numbers for datadog_extension_layer_version can be found here: <https://
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | Amount of reserved concurrent executions for this lambda function | `number` | `100` | no |
 | <a name="input_retention"></a> [retention](#input\_retention) | The log group retention in days | `number` | `30` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | The version of the runtime to use | `string` | `"3.11"` | no |
-| <a name="input_s3_access_logging_bucket"></a> [s3\_access\_logging\_bucket](#input\_s3\_access\_logging\_bucket) | The bucket name for S3 access logging | `string` | `""` | no |
 | <a name="input_sns_topic_arns"></a> [sns\_topic\_arns](#input\_sns\_topic\_arns) | SNS Topic ARNs | `list(string)` | <pre>[<br>  "undefined"<br>]</pre> | no |
 | <a name="input_store_failed_events"></a> [store\_failed\_events](#input\_store\_failed\_events) | Whether to store failed events in the log forwarder | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to assign to resources created by this module | `map(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -311,6 +311,7 @@ resource "aws_lambda_permission" "rds_logs" {
   source_arn    = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/rds/*:*"
 }
 
+# tfsec:ignore:aws-s3-enable-bucket-logging
 module "datadog_serverless_s3" {
   source      = "git@github.com:smartrent/terraform-aws-s3.git?ref=2.1.0"
   bucket_name = "datadog-lambda-logs-${local.account_id}-${var.environment_name}-${var.aws_region}"

--- a/main.tf
+++ b/main.tf
@@ -312,12 +312,16 @@ resource "aws_lambda_permission" "rds_logs" {
 }
 
 module "datadog_serverless_s3" {
-  source                = "git@github.com:smartrent/terraform-aws-s3.git?ref=2.1.0"
-  bucket_name           = "datadog-lambda-logs-${local.account_id}-${var.environment_name}-${var.aws_region}"
-  target_logging_bucket = var.s3_access_logging_bucket
-  aws_region            = var.aws_region
-  enable_bucket_key     = true
-  kms_master_key_arn    = aws_kms_key.datadog.arn
-  sse_algorithm         = "aws:kms"
-  tags                  = local.tags
+  source      = "git@github.com:smartrent/terraform-aws-s3.git?ref=2.1.0"
+  bucket_name = "datadog-lambda-logs-${local.account_id}-${var.environment_name}-${var.aws_region}"
+  # since this bucket is accessed by the datadog lambda function during invocation
+  # we don't want to recursively invoke the function by sending the logs to a bucket
+  # that triggers the function
+  disable_access_logging                 = true
+  bypass_default_security_configurations = true
+  aws_region                             = var.aws_region
+  enable_bucket_key                      = true
+  kms_master_key_arn                     = aws_kms_key.datadog.arn
+  sse_algorithm                          = "aws:kms"
+  tags                                   = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,9 +106,3 @@ variable "store_failed_events" {
   description = "Whether to store failed events in the log forwarder"
   default     = true
 }
-
-variable "s3_access_logging_bucket" {
-  type        = string
-  description = "The bucket name for S3 access logging"
-  default     = ""
-}


### PR DESCRIPTION
## Description

Since the lambda function is checking / writing to this new tags cache / backups bucket during every invocation, if we have access logging enabled on the bucket, it will increase invocation rates since access logs bucket triggers the lambda. 

[Logs example](https://app.datadoghq.com/logs?query=source%3As3%20%40s3.bucket%3Adatadog-lambda-logs-%2A%20&agg_m=count&agg_m_source=base&agg_q=host%2Cservice&agg_q_source=base%2Cbase&agg_t=count&cols=core_host%2Ccore_service&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1725796380958&to_ts=1726055580958&live=true). 

[Example invocations on a low traffic region](https://app.datadoghq.com/functions?cloud=aws&entity_view=lambda_functions&fromUser=false&panel_end=1726057320000&panel_paused=false&panel_start=1725798120000&sp=%5B%7B%22p%22%3A%7B%22entityId%22%3A%22aws-lambda-functions%2Blogs_to_datadog%2Bap-northeast-3%2B514496004130%22%7D%2C%22i%22%3A%22lambda-panel%22%7D%5D&text_search=env%3Aeng&start=1726053402681&end=1726057002681&paused=false). Kinda hard to tell on busier regions. 

Maybe not enough to be concerned? What do ya'll think?

Asked DD support about it just to see what their recommendations were. They confirmed we shouldn't enable access logging for this cache bucket because it is accessed by the bucket on every invocation of the forwarder lambda. 