### PR TITLE
TECH: KMS key permission restrictions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,11 @@ data "aws_iam_policy_document" "kms_key_policy" {
       "kms:DescribeKey",
     ]
     resources = ["*"]
+    condition {
+      test     = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda/${aws_lambda_function.logs_to_datadog.function_name}"]
+    }
   }
 }
 
@@ -248,8 +253,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_kms_policy" {
       "kms:GenerateDataKey*",
       "kms:Describe*",
     ]
-    #tfsec:ignore:aws-iam-no-policy-wildcards
-    resources = ["*"]
+    resources = [aws_kms_key.datadog.arn]
     condition {
       test     = "ArnEquals"
       variable = "kms:EncryptionContext:aws:logs:arn"

--- a/main.tf
+++ b/main.tf
@@ -16,9 +16,13 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_kms_key" "datadog" {
   description         = "KMS key for datadog lambda"
-  policy              = data.aws_iam_policy_document.kms_key_policy.json
   enable_key_rotation = true
   tags                = local.tags
+}
+
+resource "aws_kms_key_policy" "datadog" {
+  key_id = aws_kms_key.datadog.id
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 resource "aws_kms_alias" "datadog" {
@@ -239,6 +243,8 @@ resource "aws_cloudwatch_log_group" "log_group" {
   retention_in_days = var.retention
   kms_key_id        = aws_kms_alias.datadog.arn
   tags              = local.tags
+
+  depends_on = [aws_kms_key_policy.datadog]
 }
 
 resource "aws_sns_topic_subscription" "sns_topic_arns" {

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
     effect = "Allow"
     principals {
       type        = "Service"
-      identifiers = ["logs.amazonaws.com"]
+      identifiers = ["logs.${var.aws_region}.amazonaws.com"]
     }
     actions = [
       "kms:Encrypt",

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,11 +29,3 @@ output "bucket_name" {
 output "bucket_arns" {
   value = module.datadog_serverless_s3.bucket_arn
 }
-
-output "cloudwatch_role_arn" {
-  value = aws_iam_role.cloudwatch_logs_role.arn
-}
-
-output "clouddwatch_kms_policy" {
-  value = aws_iam_policy.cloudwatch_logs_kms_policy.arn
-}


### PR DESCRIPTION
## Description

Restricting KMS key usage to only a single log group and specifying logs region in the service endpoint. 
Created a KMS key policy resource instead of inline param in the kms resource since this prevents cycle errors. Cloudwatch logs should depend on this resource so that the policy gets created before cloudwatch log group. 

My understanding of this is that we don't need the separate IAM role for cloudwatch to use the KMS key, we just need to KMS key policy. We've done similar in zipato_bridge for example. 
Applied in dev and still getting logs into cloudwatch without the role. 

Docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html