### PR TITLE
TECH-4834: Prevent Ingestion for Logs excluded from indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Version numbers for datadog_extension_layer_version can be found here: <https://
 | <a name="input_dd_site"></a> [dd\_site](#input\_dd\_site) | The Datadog Site Address | `string` | n/a | yes |
 | <a name="input_enhanced_metrics"></a> [enhanced\_metrics](#input\_enhanced\_metrics) | Whether Datadog enhanced metrics is enabled | `bool` | `false` | no |
 | <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | Environment name: dev, qa, prod | `string` | n/a | yes |
+| <a name="input_exclude_logs_regex"></a> [exclude\_logs\_regex](#input\_exclude\_logs\_regex) | Regex pattern to exclude logs from forwarding to Datadog | `string` | `"\"(START|END) RequestId:\\s"` | no |
 | <a name="input_layers"></a> [layers](#input\_layers) | Whether or not to use layers | `bool` | `false` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory in MB your Lambda Function can use at runtime | `number` | `1024` | no |
 | <a name="input_provision_trigger"></a> [provision\_trigger](#input\_provision\_trigger) | Whether or not to create a lambda trigger from an SNS topic | `bool` | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -35,23 +35,19 @@ Version numbers for datadog_extension_layer_version can be found here: <https://
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
-| [aws_iam_policy.cloudwatch_logs_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.labmda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.cloudwatch_logs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cloudwatch_logs_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_datadog_push](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key_policy.datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_lambda_function.logs_to_datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.rds_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.sns_topic_arns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_secretsmanager_secret.api-key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_sns_topic_subscription.sns_topic_arns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.cloudwatch_logs_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cloudwatch_logs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_runtime](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -86,8 +82,6 @@ Version numbers for datadog_extension_layer_version can be found here: <https://
 |------|-------------|
 | <a name="output_bucket_arns"></a> [bucket\_arns](#output\_bucket\_arns) | n/a |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
-| <a name="output_clouddwatch_kms_policy"></a> [clouddwatch\_kms\_policy](#output\_clouddwatch\_kms\_policy) | n/a |
-| <a name="output_cloudwatch_role_arn"></a> [cloudwatch\_role\_arn](#output\_cloudwatch\_role\_arn) | n/a |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | n/a |
 | <a name="output_lambda_api_key_secret"></a> [lambda\_api\_key\_secret](#output\_lambda\_api\_key\_secret) | n/a |
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | n/a |

--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_STORE_FAILED_EVENTS = var.store_failed_events
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
       DD_LOG_LEVEL           = "debug"
-      ## Filter out lambda platform logs / DW s3 access logs / zipato device ota 304 logs
-      EXCLUDE_AT_MATCH = "\"(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|\"9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
+      EXCLUDE_AT_MATCH       = var.exclude_logs_regex
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
       DD_LOG_LEVEL           = "debug"
       ## Filter out lambda platform logs / DW s3 access logs / zipato device ota 304 logs
-      EXCLUDE_AT_MATCH = "(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|\"9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
+      EXCLUDE_AT_MATCH = "\"(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|\"9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -86,22 +86,12 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_ENHANCED_METRICS    = var.enhanced_metrics
       DD_STORE_FAILED_EVENTS = var.store_failed_events
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
-      ## Filter out lambda platform logs
+      ## Filter out lambda platform logs / DW s3 access logs / zipato device ota 304 logs
       DD_LOGS_CONFIG_PROCESSING_RULES = jsonencode([
         {
           type    = "exclude_at_match",
-          name    = "exclude_start_and_end_lamda_platform_logs",
-          pattern = "(START|END) RequestId"
-        },
-        {
-          type    = "exclude_at_match",
-          name    = "exclude_dms_s3_access_logs",
-          pattern = "(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)" # The canonical ID of the AWS account that owns the bucket (dw-us-dev/qa/prod accounts)
-        },
-        {
-          type    = "exclude_at_match",
-          name    = "exclude_ota_device_logs_304",
-          pattern = "/device-ota/.*\\s304"
+          name    = "exclude_logs",
+          pattern = "(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
         }
       ])
     }

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_ENHANCED_METRICS    = var.enhanced_metrics
       DD_STORE_FAILED_EVENTS = var.store_failed_events
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
+      DD_LOG_LEVEL           = "debug"
       ## Filter out lambda platform logs / DW s3 access logs / zipato device ota 304 logs
       DD_LOGS_CONFIG_PROCESSING_RULES = jsonencode([
         {

--- a/main.tf
+++ b/main.tf
@@ -88,13 +88,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
       DD_LOG_LEVEL           = "debug"
       ## Filter out lambda platform logs / DW s3 access logs / zipato device ota 304 logs
-      DD_LOGS_CONFIG_PROCESSING_RULES = jsonencode([
-        {
-          type    = "exclude_at_match",
-          name    = "exclude_logs",
-          pattern = "(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|\"9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
-        }
-      ])
+      EXCLUDE_AT_MATCH = "(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|\"9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
         {
           type    = "exclude_at_match",
           name    = "exclude_logs",
-          pattern = "(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
+          pattern = "(START|END) RequestId|(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|\"9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)|/device-ota/.*\\s304"
         }
       ])
     }

--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,24 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_STORE_FAILED_EVENTS = var.store_failed_events
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
       ## Filter out lambda platform logs
-      DD_LOGS_CONFIG_PROCESSING_RULES = "[{\"type\": \"exclude_at_match\", \"name\": \"exclude_start_and_end_logs\", \"pattern\": \"(START|END) RequestId\"}]"
-      EXCLUDE_AT_MATCH                = "\"(START|END) RequestId:\\s"
+      DD_LOGS_CONFIG_PROCESSING_RULES = "[{\"type\": \"exclude_at_match\", \"name\": \"exclude_start_and_end_logs\", \"pattern\": \"(START|END) RequestId\" }]"
+      DD_LOGS_CONFIG_PROCESSING_RULES = jsonencode([
+        {
+          type    = "exclude_at_match",
+          name    = "exclude_start_and_end_lamda_platform_logs",
+          pattern = "(START|END) RequestId"
+        },
+        {
+          type    = "exclude_at_match",
+          name    = "exclude_dms_s3_access_logs",
+          pattern = "(cb6286a0d1e7cf75494d129a44503b1e5238eca143859e52c4e36251c9527208|f0f74535e58c162dd3ac99ed60ebfaf413518e6e212a5d364ce226cbed800d01|9842704febb1bf081c69ebcd73febd166602d29de15d30268d3f27ac0b0bedb8)" # The canonical ID of the AWS account that owns the bucket (dw-us-dev/qa/prod accounts)
+        },
+        {
+          type    = "exclude_at_match",
+          name    = "exclude_ota_device_logs_304",
+          pattern = "/device-ota/.*\\s304$"
+        }
+      ])
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ resource "aws_lambda_function" "logs_to_datadog" {
         {
           type    = "exclude_at_match",
           name    = "exclude_ota_device_logs_304",
-          pattern = "/device-ota/.*\\s304$"
+          pattern = "/device-ota/.*\\s304"
         }
       ])
     }

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,6 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_STORE_FAILED_EVENTS = var.store_failed_events
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
       ## Filter out lambda platform logs
-      DD_LOGS_CONFIG_PROCESSING_RULES = "[{\"type\": \"exclude_at_match\", \"name\": \"exclude_start_and_end_logs\", \"pattern\": \"(START|END) RequestId\" }]"
       DD_LOGS_CONFIG_PROCESSING_RULES = jsonencode([
         {
           type    = "exclude_at_match",

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,6 @@ resource "aws_lambda_function" "logs_to_datadog" {
       DD_ENHANCED_METRICS    = var.enhanced_metrics
       DD_STORE_FAILED_EVENTS = var.store_failed_events
       DD_S3_BUCKET_NAME      = module.datadog_serverless_s3.bucket_name
-      DD_LOG_LEVEL           = "debug"
       EXCLUDE_AT_MATCH       = var.exclude_logs_regex
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,9 @@ variable "store_failed_events" {
   description = "Whether to store failed events in the log forwarder"
   default     = true
 }
+
+variable "exclude_logs_regex" {
+  type        = string
+  description = "Regex pattern to exclude logs from forwarding to Datadog"
+  default     = "\"(START|END) RequestId:\\s"
+}


### PR DESCRIPTION
## Description
Use a variable to allow specific exclusions per environment.  Keep the START|END lambda platform logs as a default.  Essentially a net-0 change.


## Steps to Test

## Links

https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring#log-filtering-optional

## Screenshots
