### PR TITLE
TECH-8118: Disable trivy and tfsec scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,19 +43,6 @@ jobs:
             tflint --init --config ~/project/.tflint.hcl
             tflint --module
 
-  # tfsec:  # DISABLED - tfsec compromised
-  # <<: *terraform-docker-image
-  # steps:
-  # - checkout
-  # - run:
-  # name: tfsec
-  # command: |
-  # terraform --version
-  # tfsec --version
-
-            terraform init -input=false -backend=false
-            tfsec
-
 workflows:
   wf-terraform:
     jobs:
@@ -67,7 +54,3 @@ workflows:
     jobs:
     - tflint:
         name: tflint
-  # wf-tfsec:  # DISABLED - tfsec compromised
-  # jobs:
-  # - tfsec:
-  # name: tfsec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,15 +43,15 @@ jobs:
             tflint --init --config ~/project/.tflint.hcl
             tflint --module
 
-  tfsec:
-    <<: *terraform-docker-image
-    steps:
-      - checkout
-      - run:
-          name: tfsec
-          command: |
-            terraform --version
-            tfsec --version
+  # tfsec:  # DISABLED - tfsec compromised
+  # <<: *terraform-docker-image
+  # steps:
+  # - checkout
+  # - run:
+  # name: tfsec
+  # command: |
+  # terraform --version
+  # tfsec --version
 
             terraform init -input=false -backend=false
             tfsec
@@ -67,7 +67,7 @@ workflows:
     jobs:
     - tflint:
         name: tflint
-  wf-tfsec:
-    jobs:
-    - tfsec:
-        name: tfsec
+  # wf-tfsec:  # DISABLED - tfsec compromised
+  # jobs:
+  # - tfsec:
+  # name: tfsec

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,5 @@
 terraform 1.5.7
 tflint 0.51.1
-tfsec 1.28.0
-trivy 0.51.2
+# tfsec 1.28.0
 terraform-docs 0.17.0
 pre-commit 3.6.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,4 @@
 terraform 1.5.7
 tflint 0.51.1
-# tfsec 1.28.0
 terraform-docs 0.17.0
 pre-commit 3.6.2


### PR DESCRIPTION
## Summary
- Trivy has been compromised — disabling all Trivy and tfsec scanning across CI
- Removes  from 
- Comments out  in 
- Comments out  from GitHub Actions workflow calls
- Removes Trivy job/workflow sections from CircleCI configs
- Comments out tfsec job/workflow sections from CircleCI configs
- Removes  config files where present

## Context
Security incident: Trivy supply chain compromise. Disabling Trivy and tfsec (deprecated, replaced by Trivy) until further notice.

## Test plan
- [ ] CI passes without trivy/tfsec steps
- [ ] No active trivy/tfsec references remain in CI configs
